### PR TITLE
Fix crash on app exit

### DIFF
--- a/electron-overlay/src/overlay.h
+++ b/electron-overlay/src/overlay.h
@@ -442,7 +442,9 @@ class OverlayMain : public IIpcHost
         Napi::Function callback = info[0].As<Napi::Function>();
 
         eventCallback_ = std::make_shared<NodeEventCallback>(env, Napi::Persistent(callback), Napi::Persistent(info.This().ToObject()));
-
+        eventCallback_->callback.SuppressDestruct();
+        eventCallback_->receiver.SuppressDestruct();
+        
         return env.Undefined();
     }
 


### PR DESCRIPTION
I have noticed that the electron app is crashing on exit every time when trying to destroy the objects inside eventCallback_. This fixes the issue.